### PR TITLE
Fix setup.cfg deperaceted report

### DIFF
--- a/URDF_Exporter_Ros2/package/setup.cfg
+++ b/URDF_Exporter_Ros2/package/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/fusion2urdf_ros2
+script_dir=$base/lib/fusion2urdf_ros2
 [install]
-install-scripts=$base/lib/fusion2urdf_ros2
+install_scripts=$base/lib/fusion2urdf_ros2

--- a/URDF_Exporter_Ros2/utils/utils.py
+++ b/URDF_Exporter_Ros2/utils/utils.py
@@ -182,10 +182,10 @@ def update_setup_cfg(save_dir, package_name):
     file_name = save_dir + '/setup.cfg'
 
     for line in fileinput.input(file_name, inplace=True):
-        if "script-dir" in line:
-            sys.stdout.write("script-dir=$base/lib/" + package_name + "\n")
-        elif "install-scripts" in line:
-            sys.stdout.write("install-scripts=$base/lib/" + package_name + "\n")
+        if "script_dir" in line:
+            sys.stdout.write("script_dir=$base/lib/" + package_name + "\n")
+        elif "install_scripts" in line:
+            sys.stdout.write("install_scripts=$base/lib/" + package_name + "\n")
         else:
             sys.stdout.write(line)
 


### PR DESCRIPTION
This PR fixed a problem that "script-dir" is deperaceted in ros2-humble, which will cause an error report when trying to execute "colcon build" command.