### PR TITLE
fix python >= 3.9，ModuleNotFoundError: No module named 'distutils'

### DIFF
--- a/URDF_Exporter_Ros2/utils/utils.py
+++ b/URDF_Exporter_Ros2/utils/utils.py
@@ -4,14 +4,39 @@ Created on Sun May 12 19:15:34 2019
 
 @author: syuntoku
 """
-
+import sys
 import adsk, adsk.core, adsk.fusion
 import os.path, re
 from xml.etree import ElementTree
 from xml.dom import minidom
-from distutils.dir_util import copy_tree
+# from distutils.dir_util import copy_tree
+# from shutil import copytree as copy_tree
 import fileinput
-import sys
+
+import shutil
+import os
+
+
+def copy_tree(src, dst):
+    # 如果目标目录不存在，创建目标目录
+    if not os.path.exists(dst):
+        os.makedirs(dst)
+
+    # 遍历源目录中的文件和文件夹
+    for item in os.listdir(src):
+        s = os.path.join(src, item)
+        d = os.path.join(dst, item)
+        if os.path.isdir(s):
+            # 递归复制子目录
+            copy_tree(s, d)
+        else:
+            # 复制文件
+            shutil.copy2(s, d)
+
+
+# 使用示例
+# copy_tree('source_folder', 'destination_folder')
+
 
 def copy_occs(root):
     """


### PR DESCRIPTION
当系统python版本>=3.9时，在实际运行过程中会出现缺失distuils库的问题
![Snipaste_2024-11-07_18-52-47](https://github.com/user-attachments/assets/b8d47c44-f5cc-4de6-b090-3bb81a970282)
且高版本不再支持distuils，无法通过pip install distuils直接安装，此处是直接写了一份新的函数，来作为原函数引用的替代。
使得fusion2urdf-ros2可支持高版本python。

When the system python version >= 3.9, there is a problem with the missing distuils library during the actual runtime
And higher versions no longer support distuils, can not be installed directly through pip install distuils, here is a direct write a new copy of the function, to serve as a replacement for the original function reference.
Make fusion2urdf-ros2 can support high version python.